### PR TITLE
Enable CSV upload in Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,14 @@
+import streamlit as st
+import pandas as pd
+
+
+def main():
+    st.title("SMS Statistics")
+    uploaded_file = st.file_uploader("Загрузите CSV", type=["csv"])
+    if uploaded_file is not None:
+        df = pd.read_csv(uploaded_file, parse_dates=["Date / Time"])
+        st.write(df)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add Streamlit app that reads uploaded CSV files and parses `Date / Time` column

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08e619c0483268a09cf204107ac66